### PR TITLE
Request READ_EXTERNAL_STORAGE permission at runtime

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -44,6 +44,9 @@ xmlns:android="http://schemas.android.com/apk/res/android"
             </feature>
         </config-file>
 
+        <framework src="com.android.support:support-v4:25.+" />
+        <framework src="com.android.support:appcompat-v7:25.+" />
+
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/src/android/FilePath.java
+++ b/src/android/FilePath.java
@@ -1,8 +1,10 @@
 package com.hiddentao.cordova.filepath;
 
 
+import android.Manifest;
 import android.content.ContentUris;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.util.Log;
 import android.database.Cursor;
@@ -10,6 +12,7 @@ import android.os.Build;
 import android.os.Environment;
 import android.provider.DocumentsContract;
 import android.provider.MediaStore;
+import android.support.v4.app.ActivityCompat;
 
 import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaInterface;
@@ -34,9 +37,15 @@ public class FilePath extends CordovaPlugin {
     private static final int GET_CLOUD_PATH_ERROR_CODE = 1;
     private static final String GET_CLOUD_PATH_ERROR_ID = "cloud";
 
+    private static final int RC_READ_EXTERNAL_STORAGE = 5;
 
     public void initialize(CordovaInterface cordova, final CordovaWebView webView) {
         super.initialize(cordova, webView);
+
+        // Check whether we have the read storage permission.
+        if (ActivityCompat.checkSelfPermission(this.cordova.getActivity(), Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(this.cordova.getActivity(), new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, RC_READ_EXTERNAL_STORAGE);
+        }
     }
 
     /**


### PR DESCRIPTION
This small modification should fix the Permission Denial problem on newer Android versions. When the plugin it initialised it will check for READ_EXTERNAL_STORAGE permission and request it if it is not granted.

Note: it's a very basic fix and can be enhanced.