### PR TITLE
Added checkPermissions function

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cordova-plugin-filepath
 
-This plugin allows you to resolve the native filesystem path for Android content 
+This plugin allows you to resolve the native filesystem path for Android content
 URIs and is based on code in the [aFileChooser](https://github.com/iPaulPro/aFileChooser/blob/master/aFileChooser/src/com/ipaulpro/afilechooser/utils/FileUtils.java) library.
 
 Original inspiration [from StackOverflow](http://stackoverflow.com/questions/20067508/get-real-path-from-uri-android-kitkat-new-storage-access-framework).
@@ -17,8 +17,28 @@ $ cordova plugin add cordova-plugin-filepath
 
 ## Usage
 
-Once installed the plugin defines the `window.FilePath` object. To resolve a 
-file path:
+Once installed the plugin defines the `window.FilePath` object. Here is the full
+example of Plugin in practice:
+```js
+window.FilePath.checkPermissions(function () {
+  // got permissions
+  window.FilePath.resolveNativePath('content://...', function (nativePath) {
+    alert('Here is the native path' + nativePath);
+  },
+  function () {
+    alert('Something went wrong getting the native path.');
+  });
+}, function () {
+  // no permissions
+  alert('No permissions.');
+});
+```
+
+## Functions
+
+## `resolveNativePath`
+
+To resolve a file path:
 
 ```js
 window.FilePath.resolveNativePath('content://...', successCallback, errorCallback);
@@ -36,6 +56,13 @@ Possible error codes are:
 * ``-1`` - describes an invalid action
 * ``0`` - ``file://`` path could not be resolved
 * ``1`` - the native path links to a cloud file (e.g: from Google Drive app)
+
+## `checkPermissions`
+
+Asks the system for permissions.
+```js
+window.FilePath.checkPermissions(successCallback, errorCallback);
+```
 
 ## LICENSE
 

--- a/src/android/FilePath.java
+++ b/src/android/FilePath.java
@@ -88,7 +88,7 @@ public class FilePath extends CordovaPlugin {
         } else if (action.equals("checkPermissions")) {
 
             if (ActivityCompat.checkSelfPermission(this.cordova.getActivity(), Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
-                callbackContext.success('true');
+                callbackContext.success("true");
             }
 
             else {

--- a/src/android/FilePath.java
+++ b/src/android/FilePath.java
@@ -88,13 +88,14 @@ public class FilePath extends CordovaPlugin {
         } else if (action.equals("checkPermissions")) {
 
             if (ActivityCompat.checkSelfPermission(this.cordova.getActivity(), Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
-                callbackContext.success(true);
+                callbackContext.success('true');
             }
 
             else {
                 ActivityCompat.requestPermissions(this.cordova.getActivity(), new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, RC_READ_EXTERNAL_STORAGE);
             }
 
+            return true;
         }
         else {
             resultObj.put("code", INVALID_ACTION_ERROR_CODE);

--- a/src/android/FilePath.java
+++ b/src/android/FilePath.java
@@ -41,11 +41,6 @@ public class FilePath extends CordovaPlugin {
 
     public void initialize(CordovaInterface cordova, final CordovaWebView webView) {
         super.initialize(cordova, webView);
-
-        // Check whether we have the read storage permission.
-        if (ActivityCompat.checkSelfPermission(this.cordova.getActivity(), Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED) {
-            ActivityCompat.requestPermissions(this.cordova.getActivity(), new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, RC_READ_EXTERNAL_STORAGE);
-        }
     }
 
     /**
@@ -80,7 +75,7 @@ public class FilePath extends CordovaPlugin {
             else if (filePath.equals(GET_CLOUD_PATH_ERROR_ID)) {
                 resultObj.put("code", GET_CLOUD_PATH_ERROR_CODE);
                 resultObj.put("message", "Files from cloud cannot be resolved to filesystem, download is required.");
-                
+
                 callbackContext.error(resultObj);
             }
             else {
@@ -90,11 +85,21 @@ public class FilePath extends CordovaPlugin {
             }
 
             return true;
+        } else if (action.equals("checkPermissions")) {
+
+            if (ActivityCompat.checkSelfPermission(this.cordova.getActivity(), Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED) {
+                callbackContext.success(true);
+            }
+
+            else {
+                ActivityCompat.requestPermissions(this.cordova.getActivity(), new String[]{Manifest.permission.READ_EXTERNAL_STORAGE}, RC_READ_EXTERNAL_STORAGE);
+            }
+
         }
         else {
             resultObj.put("code", INVALID_ACTION_ERROR_CODE);
             resultObj.put("message", "Invalid action.");
-            
+
             callbackContext.error(resultObj);
         }
 
@@ -228,7 +233,7 @@ public class FilePath extends CordovaPlugin {
                 return fullPath;
             }
         }
-    
+
         // Environment.isExternalStorageRemovable() is `true` for external and internal storage
         // so we cannot relay on it.
         //

--- a/www/FilePath.js
+++ b/www/FilePath.js
@@ -12,7 +12,7 @@ module.exports = {
         exec(successCallback, errorCallback, "FilePath", "resolveNativePath", [path]);
     },
 
-    checkPermissions: function(path, successCallback, errorCallback) {
+    checkPermissions: function(successCallback, errorCallback) {
       exec(successCallback, errorCallback, "FilePath", "checkPermissions", []);
   }
 };

--- a/www/FilePath.js
+++ b/www/FilePath.js
@@ -10,5 +10,9 @@ module.exports = {
      */
     resolveNativePath: function(path, successCallback, errorCallback) {
         exec(successCallback, errorCallback, "FilePath", "resolveNativePath", [path]);
-    }
+    },
+
+    checkPermissions: function(path, successCallback, errorCallback) {
+      exec(successCallback, errorCallback, "FilePath", "checkPermissions", []);
+  }
 };


### PR DESCRIPTION
A big downside to the plugin is asking user for permissions on initializing the application. As far as I know, there's no `native` app that would ask for extra permissions on app start but only on exact time where the plugin should be used.

That's why, I've updated the code, added the `checkPermissions` function and updated readme. Feel free to update/comment the PR.

For additional question, I'll be glad to help.