### PR TITLE
Remove forced android versions which cause conflicts with other plugins.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -41,9 +41,6 @@
             </feature>
         </config-file>
 
-        <framework src="com.android.support:support-v4:25.+"/>
-        <framework src="com.android.support:appcompat-v7:25.+"/>
-
         <config-file target="AndroidManifest.xml" parent="/*">
             <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
             <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>


### PR DESCRIPTION
This change fixes the following issues:
https://github.com/hiddentao/cordova-plugin-filepath/issues/33
https://github.com/hiddentao/cordova-plugin-filepath/issues/41

If you're unable to maintain this plugin in the future, please add me as a contributor or collaborator and grant me the required permissions to commit to the repo, create releases, and publish new versions of the plugin to npmjs.  Lots of people are having problems because you're not fixing this bug.  The fix only involves deleting two lines from plugin.xml.  Let's get this done.